### PR TITLE
Only set firmware paths when internal firmware is not used

### DIFF
--- a/src/android/MelonDS.cpp
+++ b/src/android/MelonDS.cpp
@@ -62,16 +62,7 @@ namespace MelonDSAndroid
     void setConfiguration(EmulatorConfiguration emulatorConfiguration) {
         currentConfiguration = emulatorConfiguration;
         actualMicSource = emulatorConfiguration.micSource;
-
-        Config::BIOS7Path = emulatorConfiguration.dsBios7Path;
-        Config::BIOS9Path = emulatorConfiguration.dsBios9Path;
-        Config::FirmwarePath = emulatorConfiguration.dsFirmwarePath;
-
-        Config::DSiBIOS7Path = emulatorConfiguration.dsiBios7Path;
-        Config::DSiBIOS9Path = emulatorConfiguration.dsiBios9Path;
-        Config::DSiFirmwarePath = emulatorConfiguration.dsiFirmwarePath;
-        Config::DSiNANDPath = emulatorConfiguration.dsiNandPath;
-
+        
         // Internal BIOS and Firmware can only be used for DS
         if (emulatorConfiguration.userInternalFirmwareAndBios) {
             Config::FirmwareUsername = emulatorConfiguration.firmwareConfiguration.username;
@@ -86,6 +77,15 @@ namespace MelonDSAndroid
             Config::ConsoleType = 0;
             Config::ExternalBIOSEnable = false;
         } else {
+            Config::BIOS7Path = emulatorConfiguration.dsBios7Path;
+            Config::BIOS9Path = emulatorConfiguration.dsBios9Path;
+            Config::FirmwarePath = emulatorConfiguration.dsFirmwarePath;
+
+            Config::DSiBIOS7Path = emulatorConfiguration.dsiBios7Path;
+            Config::DSiBIOS9Path = emulatorConfiguration.dsiBios9Path;
+            Config::DSiFirmwarePath = emulatorConfiguration.dsiFirmwarePath;
+            Config::DSiNANDPath = emulatorConfiguration.dsiNandPath;
+
             Config::ExternalBIOSEnable = true;
             Config::DirectBoot = !emulatorConfiguration.showBootScreen;
 


### PR DESCRIPTION
When the user uses internal firmware without configuring external BIOS path, a crash can be observed when running a game:

```
pid: 3681, tid: 3971, name: RxCachedThreadS  >>> me.magnum.melonds.dev <<<
    01 pc 00000000004d2ae8  /data/app/~~usflvTWmCZy5aZBFXYAWbw==/me.magnum.melonds.dev-25PisQX1TquKFQM3tiMHeA==/lib/arm64/libmelonDS-lib.so (std::__ndk1::basic_string<char, std::__ndk1::char_traits<char>, std::__ndk1::allocator<char> >::assign(char const*)+32) (BuildId: e35bf127bac26d87c4586a7e22a1ca23e0a8e37d)
    02 pc 0000000000373400  /data/app/~~usflvTWmCZy5aZBFXYAWbw==/me.magnum.melonds.dev-25PisQX1TquKFQM3tiMHeA==/lib/arm64/libmelonDS-lib.so (MelonDSAndroid::setConfiguration(MelonDSAndroid::EmulatorConfiguration)+116) (BuildId: e35bf127bac26d87c4586a7e22a1ca23e0a8e37d)
    03 pc 000000000000d5b0  /data/app/~~usflvTWmCZy5aZBFXYAWbw==/me.magnum.melonds.dev-25PisQX1TquKFQM3tiMHeA==/lib/arm64/libmelonDS-android-frontend.so (Java_me_magnum_melonds_MelonEmulator_setupEmulator+260) (BuildId: 8a43c4a5b4f6d670c96f04b0c7ca13ff73987116)
```

Inspecting setConfiguration, it seems that the firmware paths are set regardless of whether internal firmware is used. The internal firmware shouldn't require these paths, and having them unset results in the crash detailed above.

To fix this, only set the paths when required. The check for internal firmware is sufficient for this purpose.

Test:
	1. Run a clean install of melonDS, without configuring BIOS and without enabling custom BIOS & firmware (internal firmware only)
	2. Initialise a known-affected game (Pokemon HG)
	3. The game runs without any crash observed