### PR TITLE
JIT: invalidate only blocks overlapping the written code granule

### DIFF
--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -940,7 +940,7 @@ void ARMJIT::InvalidateByAddr(u32 localAddr) noexcept
 
     AddressRange* region = CodeMemRegions[localAddr >> 27];
     AddressRange* range = &region[(localAddr & 0x7FFFFFF) / 512];
-    u32 mask = 1 << ((localAddr & 0x1FF) / 16);
+    u32 invalidationMask = 1 << ((localAddr & 0x1FF) / 16);
 
     range->Code = 0;
     for (int i = 0; i < range->Blocks.Length;)
@@ -954,7 +954,7 @@ void ARMJIT::InvalidateByAddr(u32 localAddr) noexcept
             if (block->AddressRanges()[j] == (localAddr & ~0x1FF))
             {
                 mask = block->AddressMasks()[j];
-                invalidated = block->AddressMasks()[j] & mask;
+                invalidated = mask & invalidationMask;
                 assert(mask);
                 break;
             }


### PR DESCRIPTION
Target: `rafaelvcaetano/melonDS-android-lib` at `431ab4bd0003c4356e25fce89640ae1004579b9b`.

A write to one 16-byte code granule can invalidate unrelated JIT blocks in the same 512-byte range. In `ARMJIT::InvalidateByAddr`, the block mask shadows the write mask, so the overlap check compares the block mask with itself.

This two-line change gives the write mask a distinct name and tests the intended overlap. Disjoint neighbours remain cached; overlapping blocks are still invalidated.

Synthetic guest instructions and Action Replay writes reproduce this through the real core. On macOS arm64 and inside Android 13 arm64-v8a, each baseline process failed 5/13 original cases and 20/24 coverage cases. This patch alone passed all 37, including guest results and overlapping writes. Each executable ran in three fresh processes. The separate Thumb failures remained unchanged. These results demonstrate avoided invalidations/recompilations, not a game FPS improvement.

Application checks used both production fixes with no core observer. The corresponding desktop fixes were also checked in a test-linked Mac application, which exercised its real frontend event loop and load/pause/resume/stop/reopen APIs: baseline JIT produced nine red captures; combined JIT and both interpreter controls produced 27 green captures across 12 normally terminated processes. Android JNI/API checks likewise changed from three red captures to three green; the combined build passed one JIT integration test and three database-migration instrumentation tests, plus thirteen JVM tests. Green remains the correct result. These app fixtures distinguish Thumb directly and provide combined-build integration coverage for the mask fix.

Fast Memory fields in the core option matrix record requests: Apple disables it effectively, and Android did not record its effective state. Native JIT execution was verified independently. The app tests used software framebuffers/offscreen execution; no visible UI, physical-device, game-FPS or general save-compatibility claim follows.

The minimal production diff, original synthetic reproducer and observer remain separate. melonDS/JIT and Android-port credits are preserved; reproduction material is GPL-3.0-or-later.

[Core reproduction](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/invalidation-mask-android/README.md), [production diff](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/invalidation-mask-android/production/fix.patch), [core results](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/invalidation-mask-android/results/core.json), [Mac API results](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/invalidation-mask-android/results/macos-app-context.json), [Android API results](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/invalidation-mask-android/results/android-app-context.json), [shared app recipes](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/app-validation/README.md), [credits](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/invalidation-mask-android/CREDITS.md).

Related proposals: [desktop proposal](https://github.com/melonDS-emu/melonDS/pull/2745), [separate Thumb correction](https://github.com/rafaelvcaetano/melonDS-android-lib/pull/12).


Follow-up source review on 8 September confirmed the mask-shadowing cause and preservation of overlapping invalidation. The existing 37-case tests remain its runtime evidence; the newer Thumb guest is not a cache-retention test. [Review scope and limits](https://github.com/Umberto-DEV/melonDS/blob/6576f276fc6040e2c18ee9d9736c0ee5b0cc3485/jit-review-20260908/README.md#scope-and-related-mask-pr). The production diff is unchanged.

### Additional pipeline verification

[Source review and complete Mac/Android results](https://github.com/Umberto-DEV/melonDS/tree/6933a60719f3d9dacbc22c0c4a667930faeaf652/jit-pipeline-review-20260908) cover the surrounding literal-tracking, invalidation and block-reuse paths. Across both guests: 104 complete processes, 2,380 case executions, plus five omitted-load sensitivity controls. Production commits are unchanged. The new runs check this mask fix together with the Thumb fix. The earlier dedicated invalidation-count proof remains the evidence for this PR; no new performance claim is made.
