### PR TITLE
AArch64 JIT: align Thumb PC-relative loads after literal invalidation

### DIFF
--- a/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
@@ -114,7 +114,7 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
 
     if (NDS.JIT.LiteralOptimizationsEnabled() && rn == 15 && rd != 15 && offset.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
     {
-        u32 addr = R15 + offset.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
+        u32 addr = (Thumb ? (R15 & ~0x2) : R15) + offset.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
         
         if (Comp_MemLoadLiteral(size, flags & memop_SignExtend, rd, addr))
             return;


### PR DESCRIPTION
Target: `rafaelvcaetano/melonDS-android-lib` at `431ab4bd0003c4356e25fce89640ae1004579b9b`.

The alignment already present in `T_Comp_LoadPCRel` applies to its first lookup. After that literal has been invalidated, `Comp_MemAccess` tries folding again and recomputes the address from unaligned PC. This patch corrects that second lookup. Otherwise a Thumb instruction at alignment +2 can fold `0x77885566` instead of `0x55667788` and retain it after a later write of `0x99AABBCC`.

This core already declares PC as a source register, so its production fix remains the one-line address change. In the new autonomous-guest test, baseline fails 12/26 cases with folding on and this patch passes 26/26.

The same result holds on macOS AArch64 and an Android 13 ARM64 AVD across all eight combinations of folding, requested Fast Memory and branch optimization. Folding-off and interpreter controls pass. Effective options are checked: Android Fast Memory is active when requested; macOS disables it. The guest tests both CPUs, STR/STRH/STRB, two literal mutations and register/flag sentinels through normal cart boot and `NDS::RunFrame`, without core observers or direct dispatch calls.

[Follow-up source, commands, results and limitations](https://github.com/Umberto-DEV/melonDS/blob/6576f276fc6040e2c18ee9d9736c0ee5b0cc3485/jit-review-20260908/README.md). The tested production blobs match this PR head exactly; this follow-up changes the explanation and test evidence, not the production diff.

<details>
<summary>Original reproduction, application checks, performance cost and credits</summary>

A Thumb PC-relative load can return the wrong value after its folded literal changes. The fallback retries its lookup with an unaligned PC; an instruction at alignment +2 can miss the invalidated literal and return `0x77885566` instead of the new `0x55667788`.

This one-line change aligns PC for the fallback lookup. This core already records PC as a source register, so no decoder change is needed.

The synthetic test loads `0x11223344`, changes it to `0x55667788`, then checks recompilation and the resulting native block. On macOS arm64 and inside Android 13 arm64-v8a, this core's baseline failed 2/8 focused cases and 24/96 option cases. This patch alone passed all 104 on each OS. Each executable ran in three fresh processes, covering ARM7/ARM9, both alignments and literal folding on/off.

Application checks used both production fixes with no core observer. The corresponding desktop fixes were also checked in a test-linked Mac application, which exercised its real frontend event loop and load/pause/resume/stop/reopen APIs: baseline JIT produced nine red captures; combined JIT and both interpreter controls produced 27 green captures across 12 normally terminated processes. Android JNI/API checks likewise changed from three red captures to three green; the combined build passed one JIT integration test and three database-migration instrumentation tests, plus thirteen JVM tests. Green remains the correct result. These app fixtures distinguish Thumb directly and provide combined-build integration coverage for the mask fix.

Fast Memory fields in the core option matrix record requests: Apple disables it effectively, and Android did not record its effective state. Native JIT execution was verified independently. The app tests used software framebuffers/offscreen execution; no visible UI, physical-device, game-FPS or general save-compatibility claim follows.

The minimal production diff, original synthetic reproducer and observer remain separate. melonDS/JIT and Android-port credits are preserved; reproduction material is GPL-3.0-or-later.

[Core reproduction](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/thumb-literal-android/README.md), [production diff](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/thumb-literal-android/production/fix.patch), [core results](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/thumb-literal-android/results/core.json), [Mac API results](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/thumb-literal-android/results/macos-app-context.json), [Android API results](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/thumb-literal-android/results/android-app-context.json), [shared app recipes](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/app-validation/README.md), [credits](https://github.com/Umberto-DEV/melonDS/blob/8cc7cdb26880bfc0bfc4649de22a50d402137a99/jit-validation-20260907/thumb-literal-android/CREDITS.md).

Related proposals: [desktop proposal](https://github.com/melonDS-emu/melonDS/pull/2746), [separate invalidation-mask correction](https://github.com/rafaelvcaetano/melonDS-android-lib/pull/11).


</details>

### Additional pipeline verification

[Source review and complete Mac/Android results](https://github.com/Umberto-DEV/melonDS/tree/6933a60719f3d9dacbc22c0c4a667930faeaf652/jit-pipeline-review-20260908) cover the surrounding literal-tracking, invalidation and block-reuse paths. Across both guests: 104 complete processes, 2,380 case executions, plus five omitted-load sensitivity controls. Production commits are unchanged. The original 26-case guest passes with this patch. The broader guest still exposes three separate pre-existing same-block/Shared-WRAM cases; those are explicitly outside this change.
