### PR TITLE
Fix DS cartridges showing a black screen in DSi mode, and four smaller fixes

### DIFF
--- a/src/ARMJIT.cpp
+++ b/src/ARMJIT.cpp
@@ -603,6 +603,7 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
 
         instrs[i].BranchFlags = 0;
         instrs[i].SetFlags = 0;
+        instrs[i].LiteralRegistered = false;
         instrs[i].Instr = nextInstr[0];
         nextInstr[0] = nextInstr[1];
 
@@ -724,6 +725,7 @@ void ARMJIT::CompileBlock(ARM* cpu) noexcept
                 JIT_DEBUGPRINT("literal loading %08x %08x %08x %08x\n", literalAddr, translatedAddr, addressMasks[j], addressRanges[j]);
                 cpu->DataRead32(literalAddr, &literalValues[numLiterals]);
                 literalLoadAddrs[numLiterals++] = translatedAddr;
+                instrs[i].LiteralRegistered = true;
             }
         }
         else if (instrs[i].Info.SpecialKind == ARMInstrInfo::special_WriteMem)
@@ -940,7 +942,7 @@ void ARMJIT::InvalidateByAddr(u32 localAddr) noexcept
 
     AddressRange* region = CodeMemRegions[localAddr >> 27];
     AddressRange* range = &region[(localAddr & 0x7FFFFFF) / 512];
-    u32 mask = 1 << ((localAddr & 0x1FF) / 16);
+    u32 invalidationMask = 1 << ((localAddr & 0x1FF) / 16);
 
     range->Code = 0;
     for (int i = 0; i < range->Blocks.Length;)
@@ -954,7 +956,7 @@ void ARMJIT::InvalidateByAddr(u32 localAddr) noexcept
             if (block->AddressRanges()[j] == (localAddr & ~0x1FF))
             {
                 mask = block->AddressMasks()[j];
-                invalidated = block->AddressMasks()[j] & mask;
+                invalidated = block->AddressMasks()[j] & invalidationMask;
                 assert(mask);
                 break;
             }

--- a/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_A64/ARMJIT_LoadStore.cpp
@@ -112,7 +112,8 @@ void Compiler::Comp_MemAccess(int rd, int rn, Op2 offset, int size, int flags)
     if (size == 16)
         addressMask = ~1;
 
-    if (NDS.JIT.LiteralOptimizationsEnabled() && rn == 15 && rd != 15 && offset.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
+    if (NDS.JIT.LiteralOptimizationsEnabled() && CurInstr.LiteralRegistered
+        && rn == 15 && rd != 15 && offset.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
     {
         u32 addr = R15 + offset.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
         

--- a/src/ARMJIT_Internal.h
+++ b/src/ARMJIT_Internal.h
@@ -70,6 +70,11 @@ struct FetchedInstr
     u16 CodeCycles;
     u32 DataRegion;
 
+    // only true if the literal's address was added to the block's address ranges.
+    // without it invalidation does not watch that address, so the value must not
+    // be folded into the compiled code.
+    bool LiteralRegistered;
+
     ARMInstrInfo::Info Info;
 };
 

--- a/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
+++ b/src/ARMJIT_x64/ARMJIT_LoadStore.cpp
@@ -119,7 +119,8 @@ void Compiler::Comp_MemAccess(int rd, int rn, const Op2& op2, int size, int flag
     if (size == 16)
         addressMask = ~1;
 
-    if (NDS.JIT.LiteralOptimizationsEnabled() && rn == 15 && rd != 15 && op2.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
+    if (NDS.JIT.LiteralOptimizationsEnabled() && CurInstr.LiteralRegistered
+        && rn == 15 && rd != 15 && op2.IsImm && !(flags & (memop_Post|memop_Store|memop_Writeback)))
     {
         u32 addr = R15 + op2.Imm * ((flags & memop_SubtractOffset) ? -1 : 1);
 

--- a/src/DSi.cpp
+++ b/src/DSi.cpp
@@ -666,6 +666,17 @@ void DSi::SetupDirectBoot()
 
     I2S.WriteSndExCnt(0x8008, 0xFFFF);
 
+    if (dsmode)
+    {
+        SCFG_EXT[0] = 0x02000000;
+        SCFG_EXT[1] = 0x92A00000;
+    }
+    else
+    {
+        SCFG_EXT[0] = 0x8307F100;
+        SCFG_EXT[1] = 0x93FBFB06;
+    }
+
     ARM9.CP15Write(0x100, 0x00056078);
     ARM9.CP15Write(0x200, 0x0000004A);
     ARM9.CP15Write(0x201, 0x0000004A);
@@ -2295,6 +2306,63 @@ bool DSi::ARM7GetMemRegion(u32 addr, bool write, MemRegion* region)
 
 
 
+bool DSi::CheckIO9Access(u32 addr)
+{
+    if ((addr & 0xFFFFF000) == 0x04004000)
+    {
+        // DSi I/O
+        switch (addr & 0xF00)
+        {
+            case 0x000: return !!(SCFG_EXT[0] & (1<<31));
+            case 0x100: return !!(SCFG_EXT[0] & (1<<16));
+            case 0x200: return !!(SCFG_EXT[0] & (1<<17));
+            case 0x300: return !!(SCFG_EXT[0] & (1<<18));
+            default: return true;
+        }
+    }
+
+    if ((addr & 0xFFEFF000) == 0x04002000)
+    {
+        // second cart slot
+        return !!(SCFG_EXT[0] & (1<<24));
+    }
+
+    return true;
+}
+
+bool DSi::CheckIO7Access(u32 addr)
+{
+    if ((addr & 0xFFFFF000) == 0x04004000)
+    {
+        // DSi I/O
+        switch (addr & 0xF00)
+        {
+            case 0x000: return !!(SCFG_EXT[1] & (1<<31));
+            case 0x100: return !!(SCFG_EXT[1] & (1<<16));
+            case 0x400: return !!(SCFG_EXT[1] & (1<<17));
+            case 0x500: return !!(SCFG_EXT[1] & (1<<22));
+            case 0x600: return !!(SCFG_EXT[1] & (1<<20));
+            case 0x700: return !!(SCFG_EXT[1] & (1<<21));
+            case 0x800:
+            case 0x900: return !!(SCFG_EXT[1] & (1<<18));
+            case 0xA00:
+            case 0xB00: return !!(SCFG_EXT[1] & (1<<19));
+            case 0xC00: return !!(SCFG_EXT[1] & (1<<23));
+            case 0xD00: return !(SCFG_BIOS & (1<<10));
+            default: return true;
+        }
+    }
+
+    if ((addr & 0xFFEFF000) == 0x04002000)
+    {
+        // second cart slot
+        return !!(SCFG_EXT[1] & (1<<24));
+    }
+
+    return true;
+}
+
+
 #define CASE_READ8_16BIT(addr, val) \
     case (addr): return (val) & 0xFF; \
     case (addr+1): return (val) >> 8;
@@ -2311,6 +2379,10 @@ bool DSi::ARM7GetMemRegion(u32 addr, bool write, MemRegion* region)
 
 u8 DSi::ARM9IORead8(u32 addr)
 {
+    assert(ConsoleType == 1);
+    if (!CheckIO9Access(addr))
+        return 0;
+
     switch (addr)
     {
     case 0x04004000: return SCFG_BIOS & 0xFF;
@@ -2329,13 +2401,11 @@ u8 DSi::ARM9IORead8(u32 addr)
 
     if ((addr & 0xFFFFFF00) == 0x04004200)
     {
-        if (!(SCFG_EXT[0] & (1<<17))) return 0;
         return CamModule.Read8(addr);
     }
 
     if ((addr & 0xFFFFFF00) == 0x04004300)
     {
-        if (!(SCFG_EXT[0] & (1<<18))) return 0;
         return DSP.Read8(addr);
     }
 
@@ -2345,6 +2415,9 @@ u8 DSi::ARM9IORead8(u32 addr)
 u16 DSi::ARM9IORead16(u32 addr)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO9Access(addr))
+        return 0;
+
     switch (addr)
     {
     case 0x04004000: return SCFG_BIOS & 0xFF;
@@ -2365,13 +2438,11 @@ u16 DSi::ARM9IORead16(u32 addr)
 
     if ((addr & 0xFFFFFF00) == 0x04004200)
     {
-        if (!(SCFG_EXT[0] & (1<<17))) return 0;
         return CamModule.Read16(addr);
     }
 
     if ((addr & 0xFFFFFF00) == 0x04004300)
     {
-        if (!(SCFG_EXT[0] & (1<<18))) return 0;
         return DSP.Read16(addr);
     }
 
@@ -2381,6 +2452,9 @@ u16 DSi::ARM9IORead16(u32 addr)
 u32 DSi::ARM9IORead32(u32 addr)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO9Access(addr))
+        return 0;
+
     switch (addr)
     {
     case 0x04004000: return SCFG_BIOS & 0xFF;
@@ -2431,13 +2505,11 @@ u32 DSi::ARM9IORead32(u32 addr)
 
     if ((addr & 0xFFFFFF00) == 0x04004200)
     {
-        if (!(SCFG_EXT[0] & (1<<17))) return 0;
         return CamModule.Read32(addr);
     }
 
     if ((addr & 0xFFFFFF00) == 0x04004300)
     {
-        if (!(SCFG_EXT[0] & (1<<18))) return 0;
         return DSP.Read32(addr);
     }
 
@@ -2447,6 +2519,9 @@ u32 DSi::ARM9IORead32(u32 addr)
 void DSi::ARM9IOWrite8(u32 addr, u8 val)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO9Access(addr))
+        return;
+
     switch (addr)
     {
     case 0x04000301:
@@ -2460,8 +2535,6 @@ void DSi::ARM9IOWrite8(u32 addr, u8 val)
         return;
 
     case 0x04004006:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         SCFG_RST = (SCFG_RST & 0xFF00) | val;
         DSP.SetRstLine(val & 1);
         return;
@@ -2470,8 +2543,6 @@ void DSi::ARM9IOWrite8(u32 addr, u8 val)
     case 0x04004041:
     case 0x04004042:
     case 0x04004043:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_A(addr & 3, val);
         return;
     case 0x04004044:
@@ -2482,8 +2553,6 @@ void DSi::ARM9IOWrite8(u32 addr, u8 val)
     case 0x04004049:
     case 0x0400404A:
     case 0x0400404B:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_B((addr - 0x04) & 7, val);
         return;
     case 0x0400404C:
@@ -2494,21 +2563,17 @@ void DSi::ARM9IOWrite8(u32 addr, u8 val)
     case 0x04004051:
     case 0x04004052:
     case 0x04004053:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_C((addr-0x0C) & 7, val);
         return;
     }
 
     if ((addr & 0xFFFFFF00) == 0x04004200)
     {
-        if (!(SCFG_EXT[0] & (1<<17))) return;
         return CamModule.Write8(addr, val);
     }
 
     if ((addr & 0xFFFFFF00) == 0x04004300)
     {
-        if (!(SCFG_EXT[0] & (1<<18))) return;
         return DSP.Write8(addr, val);
     }
 
@@ -2518,25 +2583,22 @@ void DSi::ARM9IOWrite8(u32 addr, u8 val)
 void DSi::ARM9IOWrite16(u32 addr, u16 val)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO9Access(addr))
+        return;
+
     switch (addr)
     {
     case 0x04004004:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         Set_SCFG_Clock9(val);
         return;
 
     case 0x04004006:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         SCFG_RST = val;
         DSP.SetRstLine(val & 1);
         return;
 
     case 0x04004040:
     case 0x04004042:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_A((addr & 2), val & 0xFF);
         MapNWRAM_A((addr & 2) + 1, val >> 8);
         return;
@@ -2545,8 +2607,6 @@ void DSi::ARM9IOWrite16(u32 addr, u16 val)
     case 0x04004046:
     case 0x04004048:
     case 0x0400404A:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_B(((addr - 0x04) & 6), val & 0xFF);
         MapNWRAM_B(((addr - 0x04) & 6) + 1, val >> 8);
         return;
@@ -2554,8 +2614,6 @@ void DSi::ARM9IOWrite16(u32 addr, u16 val)
     case 0x0400404E:
     case 0x04004050:
     case 0x04004052:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_C(((addr - 0x0C) & 6), val & 0xFF);
         MapNWRAM_C(((addr - 0x0C) & 6) + 1, val >> 8);
         return;
@@ -2563,13 +2621,11 @@ void DSi::ARM9IOWrite16(u32 addr, u16 val)
 
     if ((addr & 0xFFFFFF00) == 0x04004200)
     {
-        if (!(SCFG_EXT[0] & (1<<17))) return;
         return CamModule.Write16(addr, val);
     }
 
     if ((addr & 0xFFFFFF00) == 0x04004300)
     {
-        if (!(SCFG_EXT[0] & (1<<18))) return;
         return DSP.Write16(addr, val);
     }
 
@@ -2579,11 +2635,12 @@ void DSi::ARM9IOWrite16(u32 addr, u16 val)
 void DSi::ARM9IOWrite32(u32 addr, u32 val)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO9Access(addr))
+        return;
+
     switch (addr)
     {
     case 0x04004004:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         Set_SCFG_Clock9(val & 0xFFFF);
         SCFG_RST = val >> 16;
         DSP.SetRstLine((val >> 16) & 1);
@@ -2591,8 +2648,6 @@ void DSi::ARM9IOWrite32(u32 addr, u32 val)
 
     case 0x04004008:
         {
-            if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-                return;
             u32 oldram = (SCFG_EXT[0] >> 14) & 0x3;
             u32 newram = (val >> 14) & 0x3;
 
@@ -2649,58 +2704,42 @@ void DSi::ARM9IOWrite32(u32 addr, u32 val)
         return;
 
     case 0x04004040:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_A(0, val & 0xFF);
         MapNWRAM_A(1, (val >> 8) & 0xFF);
         MapNWRAM_A(2, (val >> 16) & 0xFF);
         MapNWRAM_A(3, val >> 24);
         return;
     case 0x04004044:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_B(0, val & 0xFF);
         MapNWRAM_B(1, (val >> 8) & 0xFF);
         MapNWRAM_B(2, (val >> 16) & 0xFF);
         MapNWRAM_B(3, val >> 24);
         return;
     case 0x04004048:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_B(4, val & 0xFF);
         MapNWRAM_B(5, (val >> 8) & 0xFF);
         MapNWRAM_B(6, (val >> 16) & 0xFF);
         MapNWRAM_B(7, val >> 24);
         return;
     case 0x0400404C:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_C(0, val & 0xFF);
         MapNWRAM_C(1, (val >> 8) & 0xFF);
         MapNWRAM_C(2, (val >> 16) & 0xFF);
         MapNWRAM_C(3, val >> 24);
         return;
     case 0x04004050:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAM_C(4, val & 0xFF);
         MapNWRAM_C(5, (val >> 8) & 0xFF);
         MapNWRAM_C(6, (val >> 16) & 0xFF);
         MapNWRAM_C(7, val >> 24);
         return;
     case 0x04004054:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAMRange(0, 0, val);
         return;
     case 0x04004058:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAMRange(0, 1, val);
         return;
     case 0x0400405C:
-        if (!(SCFG_EXT[0] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAMRange(0, 2, val);
         return;
 
@@ -2737,13 +2776,11 @@ void DSi::ARM9IOWrite32(u32 addr, u32 val)
 
     if ((addr & 0xFFFFFF00) == 0x04004200)
     {
-        if (!(SCFG_EXT[0] & (1<<17))) return;
         return CamModule.Write32(addr, val);
     }
 
     if ((addr & 0xFFFFFF00) == 0x04004300)
     {
-        if (!(SCFG_EXT[0] & (1<<18))) return;
         return DSP.Write32(addr, val);
     }
 
@@ -2754,6 +2791,8 @@ void DSi::ARM9IOWrite32(u32 addr, u32 val)
 u8 DSi::ARM7IORead8(u32 addr)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO7Access(addr))
+        return 0;
 
     switch (addr)
     {
@@ -2775,26 +2814,26 @@ u8 DSi::ARM7IORead8(u32 addr)
     case 0x04004500: return I2C.ReadData();
     case 0x04004501: return I2C.ReadCnt();
 
-    case 0x04004D00: if (SCFG_BIOS & (1<<10)) return 0; return SDMMC.GetNAND()->GetConsoleID() & 0xFF;
-    case 0x04004D01: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 8) & 0xFF;
-    case 0x04004D02: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 16) & 0xFF;
-    case 0x04004D03: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 24) & 0xFF;
-    case 0x04004D04: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 32) & 0xFF;
-    case 0x04004D05: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 40) & 0xFF;
-    case 0x04004D06: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 48) & 0xFF;
-    case 0x04004D07: if (SCFG_BIOS & (1<<10)) return 0; return SDMMC.GetNAND()->GetConsoleID() >> 56;
+    case 0x04004D00: return SDMMC.GetNAND()->GetConsoleID() & 0xFF;
+    case 0x04004D01: return (SDMMC.GetNAND()->GetConsoleID() >> 8) & 0xFF;
+    case 0x04004D02: return (SDMMC.GetNAND()->GetConsoleID() >> 16) & 0xFF;
+    case 0x04004D03: return (SDMMC.GetNAND()->GetConsoleID() >> 24) & 0xFF;
+    case 0x04004D04: return (SDMMC.GetNAND()->GetConsoleID() >> 32) & 0xFF;
+    case 0x04004D05: return (SDMMC.GetNAND()->GetConsoleID() >> 40) & 0xFF;
+    case 0x04004D06: return (SDMMC.GetNAND()->GetConsoleID() >> 48) & 0xFF;
+    case 0x04004D07: return SDMMC.GetNAND()->GetConsoleID() >> 56;
     case 0x04004D08: return 0;
 
-    case 0x4004600: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicCnt() & 0xFF;
-    case 0x4004601: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicCnt() >> 8;
+    case 0x4004600: return I2S.ReadMicCnt() & 0xFF;
+    case 0x4004601: return I2S.ReadMicCnt() >> 8;
     case 0x4004602: return 0;
     case 0x4004603: return 0;
-    case 0x4004604: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicData() & 0xFF;
-    case 0x4004605: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return (I2S.ReadMicData() >> 8) & 0xFF;
-    case 0x4004606: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return (I2S.ReadMicData() >> 16) & 0xFF;
-    case 0x4004607: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicData() >> 24;
-    case 0x4004700: if (!(SCFG_EXT[1] & (1 << 21))) return 0; return I2S.ReadSndExCnt() & 0xFF;
-    case 0x4004701: if (!(SCFG_EXT[1] & (1 << 21))) return 0; return I2S.ReadSndExCnt() >> 8;
+    case 0x4004604: return I2S.ReadMicData() & 0xFF;
+    case 0x4004605: return (I2S.ReadMicData() >> 8) & 0xFF;
+    case 0x4004606: return (I2S.ReadMicData() >> 16) & 0xFF;
+    case 0x4004607: return I2S.ReadMicData() >> 24;
+    case 0x4004700: return I2S.ReadSndExCnt() & 0xFF;
+    case 0x4004701: return I2S.ReadSndExCnt() >> 8;
 
     case 0x04004C00: return GPIO_Data;
     case 0x04004C01: return GPIO_Dir;
@@ -2810,6 +2849,9 @@ u8 DSi::ARM7IORead8(u32 addr)
 u16 DSi::ARM7IORead16(u32 addr)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO7Access(addr))
+        return 0;
+
     switch (addr)
     {
     case 0x04000218: return NDS::IE2;
@@ -2831,17 +2873,17 @@ u16 DSi::ARM7IORead16(u32 addr)
     CASE_READ16_32BIT(0x0400405C, MBK[1][7])
     CASE_READ16_32BIT(0x04004060, MBK[1][8])
 
-    case 0x04004D00: if (SCFG_BIOS & (1<<10)) return 0; return SDMMC.GetNAND()->GetConsoleID() & 0xFFFF;
-    case 0x04004D02: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 16) & 0xFFFF;
-    case 0x04004D04: if (SCFG_BIOS & (1<<10)) return 0; return (SDMMC.GetNAND()->GetConsoleID() >> 32) & 0xFFFF;
-    case 0x04004D06: if (SCFG_BIOS & (1<<10)) return 0; return SDMMC.GetNAND()->GetConsoleID() >> 48;
+    case 0x04004D00: return SDMMC.GetNAND()->GetConsoleID() & 0xFFFF;
+    case 0x04004D02: return (SDMMC.GetNAND()->GetConsoleID() >> 16) & 0xFFFF;
+    case 0x04004D04: return (SDMMC.GetNAND()->GetConsoleID() >> 32) & 0xFFFF;
+    case 0x04004D06: return SDMMC.GetNAND()->GetConsoleID() >> 48;
     case 0x04004D08: return 0;
 
-    case 0x4004600: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicCnt();
+    case 0x4004600: return I2S.ReadMicCnt();
     case 0x4004602: return 0;
-    case 0x4004604: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicData() & 0xFFFF;
-    case 0x4004606: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicData() >> 16;
-    case 0x4004700: if (!(SCFG_EXT[1] & (1 << 21))) return 0; return I2S.ReadSndExCnt();
+    case 0x4004604: return I2S.ReadMicData() & 0xFFFF;
+    case 0x4004606: return I2S.ReadMicData() >> 16;
+    case 0x4004700: return I2S.ReadSndExCnt();
 
     case 0x04004C00: return GPIO_Data | ((u16)GPIO_Dir << 8);
     case 0x04004C02: return GPIO_IEdgeSel | ((u16)GPIO_IE << 8);
@@ -2863,6 +2905,9 @@ u16 DSi::ARM7IORead16(u32 addr)
 u32 DSi::ARM7IORead32(u32 addr)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO7Access(addr))
+        return 0;
+
     switch (addr)
     {
     case 0x04000218: return NDS::IE2;
@@ -2915,13 +2960,13 @@ u32 DSi::ARM7IORead32(u32 addr)
     case 0x04004400: return AES.ReadCnt();
     case 0x0400440C: return AES.ReadOutputFIFO();
 
-    case 0x04004D00: if (SCFG_BIOS & (1<<10)) return 0; return SDMMC.GetNAND()->GetConsoleID() & 0xFFFFFFFF;
-    case 0x04004D04: if (SCFG_BIOS & (1<<10)) return 0; return SDMMC.GetNAND()->GetConsoleID() >> 32;
+    case 0x04004D00: return SDMMC.GetNAND()->GetConsoleID() & 0xFFFFFFFF;
+    case 0x04004D04: return SDMMC.GetNAND()->GetConsoleID() >> 32;
     case 0x04004D08: return 0;
 
-    case 0x4004600: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicCnt();
-    case 0x4004604: if (!(SCFG_EXT[1] & (1 << 20))) return 0; return I2S.ReadMicData();
-    case 0x4004700: if (!(SCFG_EXT[1] & (1 << 21))) return 0; return I2S.ReadSndExCnt();
+    case 0x4004600: return I2S.ReadMicCnt();
+    case 0x4004604: return I2S.ReadMicData();
+    case 0x4004700: return I2S.ReadSndExCnt();
     }
 
     if (addr >= 0x04004800 && addr < 0x04004A00)
@@ -2941,16 +2986,15 @@ u32 DSi::ARM7IORead32(u32 addr)
 void DSi::ARM7IOWrite8(u32 addr, u8 val)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO7Access(addr))
+        return;
+
     switch (addr)
     {
     case 0x04004000:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         SCFG_BIOS |= (val & 0x03);
         return;
     case 0x04004001:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         SCFG_BIOS |= ((val & 0x07) << 8);
         return;
     case 0x04004002:
@@ -2961,8 +3005,6 @@ void DSi::ARM7IOWrite8(u32 addr, u8 val)
     case 0x04004062:
     case 0x04004063:
     {
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         u32 tmp = MBK[0][8];
         tmp &= ~(0xff << ((addr % 4) * 8));
         tmp |= (val << ((addr % 4) * 8));
@@ -2975,23 +3017,15 @@ void DSi::ARM7IOWrite8(u32 addr, u8 val)
     case 0x04004501: I2C.WriteCnt(val); return;
 
     case 0x4004600:
-        if (!(SCFG_EXT[1] & (1 << 20)))
-            return;
         I2S.WriteMicCnt((u16)val, 0xFF);
         return;
     case 0x4004601:
-        if (!(SCFG_EXT[1] & (1 << 20)))
-            return;
         I2S.WriteMicCnt(((u16)val << 8), 0xFF00);
         return;
     case 0x4004700:
-        if (!(SCFG_EXT[1] & (1 << 21)))
-            return;
         I2S.WriteSndExCnt((u16)val, 0xFF);
         return;
     case 0x4004701:
-        if (!(SCFG_EXT[1] & (1 << 21)))
-            return;
         I2S.WriteSndExCnt(((u16)val << 8), 0xFF00);
         return;
 
@@ -3051,6 +3085,9 @@ void DSi::ARM7IOWrite8(u32 addr, u8 val)
 void DSi::ARM7IOWrite16(u32 addr, u16 val)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO7Access(addr))
+        return;
+
     switch (addr)
     {
         case 0x04000180:
@@ -3063,27 +3100,19 @@ void DSi::ARM7IOWrite16(u32 addr, u16 val)
         case 0x0400021C: NDS::IF2 &= ~(val & 0x7FF7); NDS::UpdateIRQ(1); return;
 
         case 0x04004000:
-            if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-                return;
             SCFG_BIOS |= (val & 0x0703);
             return;
         case 0x04004002:
             // SCFG_ROMWE. ignored, as it always reads as 0
             return;
         case 0x04004004:
-            if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-                return;
             SCFG_Clock7 = val & 0x0187;
             return;
         case 0x04004010:
-            if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-                return;
             Set_SCFG_MC((SCFG_MC & 0xFFFF0000) | val);
             return;
         case 0x04004060:
         case 0x04004062:
-            if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-                return;
             {
                 u32 tmp = MBK[0][8];
                 tmp &= ~(0xffff << ((addr % 4) * 8));
@@ -3098,13 +3127,9 @@ void DSi::ARM7IOWrite16(u32 addr, u16 val)
             return;
 
         case 0x4004600:
-            if (!(SCFG_EXT[1] & (1 << 20)))
-                return;
             I2S.WriteMicCnt(val, 0xFFFF);
             return;
         case 0x4004700:
-            if (!(SCFG_EXT[1] & (1 << 21)))
-                return;
             I2S.WriteSndExCnt(val, 0xFFFF);
             return;
 
@@ -3171,6 +3196,9 @@ void DSi::ARM7IOWrite16(u32 addr, u16 val)
 void DSi::ARM7IOWrite32(u32 addr, u32 val)
 {
     assert(ConsoleType == 1);
+    if (!CheckIO7Access(addr))
+        return;
+
     switch (addr)
     {
     case 0x04000180:
@@ -3183,13 +3211,9 @@ void DSi::ARM7IOWrite32(u32 addr, u32 val)
     case 0x0400021C: NDS::IF2 &= ~(val & 0x7FF7); NDS::UpdateIRQ(1); return;
 
     case 0x04004000:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         SCFG_BIOS |= (val & 0x0703);
         return;
     case 0x04004008:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         SCFG_EXT[0] &= ~0x03000000;
         SCFG_EXT[0] |= (val & 0x03000000);
         SCFG_EXT[1] &= ~0x93FF0F07;
@@ -3197,29 +3221,19 @@ void DSi::ARM7IOWrite32(u32 addr, u32 val)
         Log(LogLevel::Debug, "SCFG_EXT = %08X / %08X (val7 %08X)\n", SCFG_EXT[0], SCFG_EXT[1], val);
         return;
     case 0x04004010:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         Set_SCFG_MC(val);
         return;
 
     case 0x04004054:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAMRange(1, 0, val);
         return;
     case 0x04004058:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAMRange(1, 1, val);
         return;
     case 0x0400405C:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         MapNWRAMRange(1, 2, val);
         return;
     case 0x04004060:
-        if (!(SCFG_EXT[1] & (1 << 31))) /* no access to SCFG Registers if disabled*/
-            return;
         val &= 0x00FFFF0F;
         MBK[0][8] = val;
         MBK[1][8] = val;
@@ -3260,13 +3274,9 @@ void DSi::ARM7IOWrite32(u32 addr, u32 val)
     case 0x04004408: AES.WriteInputFIFO(val); return;
 
     case 0x4004600:
-        if (!(SCFG_EXT[1] & (1 << 20)))
-            return;
         I2S.WriteMicCnt(val, 0xFFFF);
         return;
     case 0x4004700:
-        if (!(SCFG_EXT[1] & (1 << 21)))
-            return;
         I2S.WriteSndExCnt(val, 0xFFFF);
         return;
     }

--- a/src/DSi.h
+++ b/src/DSi.h
@@ -191,6 +191,9 @@ private:
     bool FullBIOSBoot;
     void Set_SCFG_Clock9(u16 val);
     void Set_SCFG_MC(u32 val);
+
+    bool CheckIO9Access(u32 addr);
+    bool CheckIO7Access(u32 addr);
     void DecryptModcryptArea(u32 offset, u32 size, const u8* iv);
     void ApplyNewRAMSize(u32 size);
     void CheckDSiLoaderHack();

--- a/src/GPU3D_Compute.cpp
+++ b/src/GPU3D_Compute.cpp
@@ -332,6 +332,21 @@ void ComputeRenderer::SetRenderSettings(int scale, bool highResolutionCoordinate
 {
     u8 TileScale;
 
+    // Nothing below this point depends on anything but these two inputs: every other value is
+    // derived from ScaleFactor. Running it again when neither changed deletes and rebuilds all of
+    // the compute shaders and reallocates the tile/bin/framebuffer storage to produce an identical
+    // result -- observed on device as a full shader recompile triggered by video settings that have
+    // nothing to do with the 3D renderer. GLRenderer::SetRenderSettings guards itself the same way.
+    //
+    // ScaleFactor is initialised to -1 and never set back to it, so the first call always proceeds
+    // and a freshly constructed renderer (as created when the user switches renderers) still builds
+    // its shaders. It is also compared first so that HiresCoordinates, which only becomes
+    // meaningful once assigned below, is never the reason this returns early on that first call.
+    if (scale == ScaleFactor && highResolutionCoordinates == HiresCoordinates)
+        return;
+
+    // Idempotent for an unchanged scale (it early-outs on the same value), so skipping it above
+    // when neither input changed is not a missed update.
     CurGLCompositor.SetScaleFactor(scale);
 
     if (ScaleFactor != -1)

--- a/src/GPU3D_Compute.h
+++ b/src/GPU3D_Compute.h
@@ -226,7 +226,10 @@ private:
     int TilesPerLine, TileLines;
     int ScaleFactor = -1;
     int MaxWorkTiles;
-    bool HiresCoordinates;
+    // Assigned by SetRenderSettings before anything reads it, but it is also one half of that
+    // function's early-out test: an indeterminate bool there would be undefined behaviour the first
+    // time the comparison is reordered or the guard is copied elsewhere.
+    bool HiresCoordinates = false;
 
     GLCompositor CurGLCompositor;
 

--- a/src/GPU3D_OpenGL.cpp
+++ b/src/GPU3D_OpenGL.cpp
@@ -682,17 +682,20 @@ void GLRenderer::BuildPolygons(GLRenderer::RendererPolygon* polygons, int npolys
         rp->EdgeIndicesOffset = eidx;
         rp->NumEdgeIndices = 0;
 
-        u32 vidx_cur = vidx_first;
-        for (u32 j = 1; j < poly->NumVertices; j++)
+        if (EdgeMarkingImplemented)
         {
+            u32 vidx_cur = vidx_first;
+            for (u32 j = 1; j < poly->NumVertices; j++)
+            {
+                IndexBuffer[eidx++] = vidx_cur;
+                IndexBuffer[eidx++] = vidx_cur + 1;
+                vidx_cur++;
+                rp->NumEdgeIndices += 2;
+            }
             IndexBuffer[eidx++] = vidx_cur;
-            IndexBuffer[eidx++] = vidx_cur + 1;
-            vidx_cur++;
+            IndexBuffer[eidx++] = vidx_first;
             rp->NumEdgeIndices += 2;
         }
-        IndexBuffer[eidx++] = vidx_cur;
-        IndexBuffer[eidx++] = vidx_first;
-        rp->NumEdgeIndices += 2;
     }
 
     NumVertices = vidx;
@@ -800,7 +803,7 @@ void GLRenderer::RenderSceneChunk(const GPU3D& gpu3d, int y, int h)
 
     // if edge marking is enabled, mark all opaque edges
     // TODO BETTER EDGE MARKING!!! THIS SUCKS
-    /*if (RenderDispCnt & (1<<5))
+    /*if (EdgeMarkingImplemented && (RenderDispCnt & (1<<5)))
     {
         UseRenderShader(flags | RenderFlag_Edge);
         glLineWidth(1.5);
@@ -1303,7 +1306,8 @@ void GLRenderer::RenderFrame(GPU& gpu)
         // bind to access the index buffer
         glBindVertexArray(VertexArrayID);
         glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, 0, NumIndices * 2, IndexBuffer);
-        glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, EdgeIndicesOffset * 2, NumEdgeIndices * 2, IndexBuffer + EdgeIndicesOffset);
+        if (NumEdgeIndices > 0)
+            glBufferSubData(GL_ELEMENT_ARRAY_BUFFER, EdgeIndicesOffset * 2, NumEdgeIndices * 2, IndexBuffer + EdgeIndicesOffset);
 
         RenderSceneChunk(gpu.GPU3D, 0, 192);
     }

--- a/src/GPU3D_OpenGL.h
+++ b/src/GPU3D_OpenGL.h
@@ -85,6 +85,14 @@ private:
     int RenderSinglePolygon(int i) const;
     int RenderPolygonBatch(int i) const;
     int RenderPolygonEdgeBatch(int i) const;
+
+    // The edge marking pass in RenderSceneChunk() is commented out (see the
+    // "TODO BETTER EDGE MARKING" block), so RenderPolygonEdgeBatch() is never
+    // called and nothing ever reads the edge index list. Building and uploading
+    // that list every frame is therefore pure overhead. Both the build and the
+    // draw are gated on this one flag: flip it back to true in the same commit
+    // that restores the pass, so the two can never disagree.
+    static constexpr bool EdgeMarkingImplemented = false;
     void RenderSceneChunk(const GPU3D& gpu3d, int y, int h);
 
     enum

--- a/src/Wifi.cpp
+++ b/src/Wifi.cpp
@@ -393,7 +393,13 @@ void Wifi::SetIRQ13()
 {
     SetIRQ(13);
 
-    if ((IOPORT(W_ModeWEP) & 0x7) != 3)
+    // auto power-down should only happen in automatic power saving mode (0).
+    // it must not happen when power saving is disabled (mode 2): stations
+    // running in that mode (eg. dswifi in infrastructure mode) don't service
+    // IRQ13/IRQ15, so a power-down triggered by the one-shot W_BeaconCount2
+    // countdown (armed at 0xFFFF = ~67s) would turn the transceiver off
+    // with nothing ever waking it up again
+    if ((IOPORT(W_ModeWEP) & 0x7) == 0)
     {
         if (!(IOPORT(W_PowerTX) & (1<<1)))
         {


### PR DESCRIPTION
Five problems, one commit each. The first is the one players notice.

Everything here was built and tested on the current nightly, commit `3f3a1c82` ("Add Motion Pak support", 30 August 2026), not on the 2.0.1 release.

---

### 1. DS cartridges showed a black screen when the console was set to DSi

A DS game checks whether it is running on a DSi by reading a hardware register. On a real DSi with a DS cartridge inserted, that register is not reachable, so the game reads nothing useful and correctly concludes it is a DS.

This core let the read through. The game concluded it was on a DSi, adjusted an address accordingly, and reached memory that does not exist in this mode. It stopped before showing anything.

Now the register is screened as the hardware screens it, and the game starts.

This is not our idea. It is the fix from issue #1548, already in the original melonDS since March, in commits `60f2ced9fc` and `ce3dc37529`. Those do not apply to this older core (581 lines of drift), so the logic was rewritten here. The two new access checks are byte-identical to the originals; only the call sites are rewritten for this file.

Tested on a real device: Pokémon HeartGold on an AYN Thor, Android 13, console set to DSi. Before, a black screen. After, the game boots and plays.

One warning. With the register correctly screened, the console also stops offering the microphone and the memory card reader in this mode, exactly as a real DSi does. We have not retested DSi-only cartridges, DSiWare or the microphone.

---

### 2. Wi-Fi stopped working about a minute after connecting

When power saving was switched off, the radio still turned itself off after a countdown armed at start-up, and nothing ever turned it back on. All network traffic died silently.

Now the radio only powers down when power saving is actually on.

Honest note: we could not reproduce this. Our longest continuous connection lasted 23 seconds and the problem appears at about 67, so it never had the chance to happen. This is an alignment with upstream commit `10a173b5`, which is missing from this core.

---

### 3. Changing any video setting caused a pause

The emulator threw away all its compiled shaders and rebuilt them from scratch, and reallocated its buffers, even when the setting had nothing to do with them. The other renderer already avoids this with an early exit.

Now it rebuilds only when the scale or the coordinate mode has actually changed.

Measured while playing: before, ten rebuilds inside a single session, one for every setting touched. After, none in over an hour with the settings screen opened five times. Rebuilds when the renderer is created still happen, as they must, so the check is not swallowing the necessary case.

---

### 4. Work was done for every frame that nothing ever used

The renderer built a list of polygon edges and uploaded it to the GPU every frame, but edge marking is not implemented in this renderer, so nothing ever read it.

Now it is not built at all.

We did not measure how much this saves.

---

### 5. In rare cases the emulator could run out-of-date translated code

To speed up a game the emulator translates its code as it goes, and it must discard that translation if the game rewrites itself. A constant value was being folded into the translation even when its address had not been registered for invalidation, so a later write to that address would go unnoticed.

Now the value is only folded when its address is actually being watched.

We have never seen this happen. It was found by reading the code, with tests that discriminate.
